### PR TITLE
Add Python 3.10 typing

### DIFF
--- a/playground_parameter_guide.md
+++ b/playground_parameter_guide.md
@@ -2,6 +2,8 @@
 
 This guide explains how to configure `interactive_playground.py` for experimenting with a prebuilt PhysTwin. The playground loads a trained PhysTwin model and the associated Gaussian Splatting representation so you can interactively control the object in real time.
 
+The Python code in this repository follows the standard type hinting syntax introduced in **Python&nbsp;3.10**.  You will therefore see annotations using built‑in generics such as `list[int]` and unions written with the `|` operator.  These hints are purely for readability and static analysis and do not affect the runtime behaviour of the scripts.
+
 ## Parameter Overview
 
 | Parameter | Default | Description |

--- a/qqtt/env/camera/realsense/multi_realsense.py
+++ b/qqtt/env/camera/realsense/multi_realsense.py
@@ -1,6 +1,7 @@
 # Description: MultiRealsense class for multiple RealSense cameras, based on code from Diffusion Policy
 
-from typing import List, Optional, Union, Dict, Callable
+from typing import List, Optional, Union, Dict
+from collections.abc import Callable
 import numbers
 import time
 from multiprocessing.managers import SharedMemoryManager
@@ -10,8 +11,8 @@ from .single_realsense import SingleRealsense
 
 class MultiRealsense:
     def __init__(self,
-        serial_numbers: Optional[List[str]]=None,
-        shm_manager: Optional[SharedMemoryManager]=None,
+        serial_numbers: list[str] | None=None,
+        shm_manager: SharedMemoryManager | None=None,
         resolution=(1280,720),
         capture_fps=30,
         put_fps=None,
@@ -21,9 +22,9 @@ class MultiRealsense:
         process_depth=False,
         enable_infrared=False,
         get_max_k=30,
-        advanced_mode_config: Optional[Union[dict, List[dict]]]=None,
-        transform: Optional[Union[Callable[[Dict], Dict], List[Callable]]]=None,
-        vis_transform: Optional[Union[Callable[[Dict], Dict], List[Callable]]]=None,
+        advanced_mode_config: dict | list[dict] | None=None,
+        transform: Callable[[dict], dict] | list[Callable] | None=None,
+        vis_transform: Callable[[dict], dict] | list[Callable] | None=None,
         verbose=False
         ):
         if shm_manager is None:
@@ -104,14 +105,14 @@ class MultiRealsense:
 
     def start_wait(self):
         for camera in self.cameras.values():
-            print('processing camera {}'.format(camera.serial_number))
+            print(f'processing camera {camera.serial_number}')
             camera.start_wait()
 
     def stop_wait(self):
         for camera in self.cameras.values():
             camera.join()
     
-    def get(self, k=None, index=None, out=None) -> Dict[int, Dict[str, np.ndarray]]:
+    def get(self, k=None, index=None, out=None) -> dict[int, dict[str, np.ndarray]]:
         """
         Return order T,H,W,C
         {

--- a/qqtt/env/camera/realsense/shared_memory/shared_memory_queue.py
+++ b/qqtt/env/camera/realsense/shared_memory/shared_memory_queue.py
@@ -15,7 +15,7 @@ class SharedMemoryQueue:
 
     def __init__(self,
             shm_manager: SharedMemoryManager,
-            array_specs: List[ArraySpec],
+            array_specs: list[ArraySpec],
             buffer_size: int
         ):
 
@@ -43,7 +43,7 @@ class SharedMemoryQueue:
     @classmethod
     def create_from_examples(cls, 
             shm_manager: SharedMemoryManager,
-            examples: Dict[str, Union[np.ndarray, numbers.Number]], 
+            examples: dict[str, np.ndarray | numbers.Number], 
             buffer_size: int
             ):
         specs = list()
@@ -87,7 +87,7 @@ class SharedMemoryQueue:
     def clear(self):
         self.read_counter.store(self.write_counter.load())
     
-    def put(self, data: Dict[str, Union[np.ndarray, numbers.Number]]):
+    def put(self, data: dict[str, np.ndarray | numbers.Number]):
         read_count = self.read_counter.load()
         write_count = self.write_counter.load()
         n_data = write_count - read_count
@@ -108,7 +108,7 @@ class SharedMemoryQueue:
         # update idx
         self.write_counter.add(1)
     
-    def get(self, out=None) -> Dict[str, np.ndarray]:
+    def get(self, out=None) -> dict[str, np.ndarray]:
         write_count = self.write_counter.load()
         read_count = self.read_counter.load()
         n_data = write_count - read_count
@@ -127,7 +127,7 @@ class SharedMemoryQueue:
         self.read_counter.add(1)
         return out
 
-    def get_k(self, k, out=None) -> Dict[str, np.ndarray]:
+    def get_k(self, k, out=None) -> dict[str, np.ndarray]:
         write_count = self.write_counter.load()
         read_count = self.read_counter.load()
         n_data = write_count - read_count
@@ -139,7 +139,7 @@ class SharedMemoryQueue:
         self.read_counter.add(k)
         return out
 
-    def get_all(self, out=None) -> Dict[str, np.ndarray]:
+    def get_all(self, out=None) -> dict[str, np.ndarray]:
         write_count = self.write_counter.load()
         read_count = self.read_counter.load()
         n_data = write_count - read_count
@@ -150,7 +150,7 @@ class SharedMemoryQueue:
         self.read_counter.add(n_data)
         return out
     
-    def _get_k_impl(self, k, read_count, out=None) -> Dict[str, np.ndarray]:
+    def _get_k_impl(self, k, read_count, out=None) -> dict[str, np.ndarray]:
         if out is None:
             out = self._allocate_empty(k)
 

--- a/qqtt/env/camera/realsense/shared_memory/shared_memory_ring_buffer.py
+++ b/qqtt/env/camera/realsense/shared_memory/shared_memory_ring_buffer.py
@@ -17,7 +17,7 @@ class SharedMemoryRingBuffer:
 
     def __init__(self, 
             shm_manager: SharedMemoryManager,
-            array_specs: List[ArraySpec],
+            array_specs: list[ArraySpec],
             get_max_k: int,
             get_time_budget: float,
             put_desired_frequency: float,
@@ -83,7 +83,7 @@ class SharedMemoryRingBuffer:
     @classmethod
     def create_from_examples(cls, 
             shm_manager: SharedMemoryManager,
-            examples: Dict[str, Union[np.ndarray, numbers.Number]], 
+            examples: dict[str, np.ndarray | numbers.Number], 
             get_max_k: int=32,
             get_time_budget: float=0.01,
             put_desired_frequency: float=60
@@ -121,7 +121,7 @@ class SharedMemoryRingBuffer:
     def clear(self):
         self.counter.store(0)
     
-    def put(self, data: Dict[str, Union[np.ndarray, numbers.Number]], wait: bool=True, serial_number: str='unknown'):
+    def put(self, data: dict[str, np.ndarray | numbers.Number], wait: bool=True, serial_number: str='unknown'):
         count = self.counter.load()
         next_idx = count % self.buffer_size
         # Make sure the next self.get_max_k elements in the ring buffer have at least 
@@ -169,7 +169,7 @@ class SharedMemoryRingBuffer:
                 shape=shape, dtype=spec.dtype)
         return result
 
-    def get(self, out=None) -> Dict[str, np.ndarray]:
+    def get(self, out=None) -> dict[str, np.ndarray]:
         if out is None:
             out = self._allocate_empty()
         start_time = time.monotonic()
@@ -184,7 +184,7 @@ class SharedMemoryRingBuffer:
             raise TimeoutError(f'Get time out {dt} vs {self.get_time_budget}')
         return out
     
-    def get_last_k(self, k:int, out=None) -> Dict[str, np.ndarray]:
+    def get_last_k(self, k:int, out=None) -> dict[str, np.ndarray]:
         assert k <= self.get_max_k
         if out is None:
             out = self._allocate_empty(k)
@@ -216,6 +216,6 @@ class SharedMemoryRingBuffer:
             raise TimeoutError(f'Get time out {dt} vs {self.get_time_budget}')
         return out
 
-    def get_all(self) -> Dict[str, np.ndarray]:
+    def get_all(self) -> dict[str, np.ndarray]:
         k = min(self.count, self.get_max_k)
         return self.get_last_k(k=k)

--- a/qqtt/env/camera/realsense/shared_memory/shared_memory_util.py
+++ b/qqtt/env/camera/realsense/shared_memory/shared_memory_util.py
@@ -7,7 +7,7 @@ from atomics import atomicview, MemoryOrder, UINT
 @dataclass
 class ArraySpec:
     name: str
-    shape: Tuple[int]
+    shape: tuple[int]
     dtype: np.dtype
 
 

--- a/qqtt/env/camera/realsense/shared_memory/shared_ndarray.py
+++ b/qqtt/env/camera/realsense/shared_memory/shared_ndarray.py
@@ -73,10 +73,10 @@ class SharedNDArray(Generic[SharedT]):
     shm: SharedMemory
     # shape: Tuple[int, ...]  # is a property
     dtype: np.dtype
-    lock: Optional[multiprocessing.synchronize.Lock]
+    lock: multiprocessing.synchronize.Lock | None
 
     def __init__(
-        self, shm: SharedMemoryLike, shape: Tuple[int, ...], dtype: npt.DTypeLike):
+        self, shm: SharedMemoryLike, shape: tuple[int, ...], dtype: npt.DTypeLike):
         """Initialize a SharedNDArray object from existing shared memory, object shape, and dtype.
         To initialize a SharedNDArray object from a memory manager and data or shape, use the `from_array()
         or `from_shape()` classmethods.
@@ -107,7 +107,7 @@ class SharedNDArray(Generic[SharedT]):
         assert shm.size >= (dtype.itemsize * np.prod(shape))
         self.shm = shm
         self.dtype = dtype
-        self._shape: Tuple[int, ...] = shape
+        self._shape: tuple[int, ...] = shape
 
     def __repr__(self):
         # Like numpy's ndarray repr
@@ -137,7 +137,7 @@ class SharedNDArray(Generic[SharedT]):
 
     @classmethod
     def create_from_shape(
-        cls, mem_mgr: SharedMemoryManager, shape: Tuple, dtype: npt.DTypeLike) -> SharedNDArray:
+        cls, mem_mgr: SharedMemoryManager, shape: tuple, dtype: npt.DTypeLike) -> SharedNDArray:
         """Create a SharedNDArray directly from a SharedMemoryManager
         Parameters
         ----------
@@ -154,7 +154,7 @@ class SharedNDArray(Generic[SharedT]):
         return cls(shm=shm, shape=shape, dtype=dtype)
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         return self._shape
 
 

--- a/qqtt/env/camera/realsense/single_realsense.py
+++ b/qqtt/env/camera/realsense/single_realsense.py
@@ -1,6 +1,7 @@
 # Description: MultiRealsense class for multiple RealSense cameras, based on code from Diffusion Policy
 
-from typing import Optional, Callable, Dict
+from typing import Optional, Dict
+from collections.abc import Callable
 import os
 import enum
 import time
@@ -41,8 +42,8 @@ class SingleRealsense(mp.Process):
             enable_infrared=False,
             get_max_k=30,
             advanced_mode_config=None,
-            transform: Optional[Callable[[Dict], Dict]] = None,
-            vis_transform: Optional[Callable[[Dict], Dict]] = None,
+            transform: Callable[[dict], dict] | None = None,
+            vis_transform: Callable[[dict], dict] | None = None,
             is_master=False,
             verbose=False
         ):

--- a/qqtt/env/camera/realsense/utils.py
+++ b/qqtt/env/camera/realsense/utils.py
@@ -6,13 +6,13 @@ import numpy as np
 
 
 def get_accumulate_timestamp_idxs(
-    timestamps: List[float],  
+    timestamps: list[float],  
     start_time: float, 
     dt: float, 
     eps:float=1e-5,
-    next_global_idx: Optional[int]=0,
+    next_global_idx: int | None=0,
     allow_negative=False
-    ) -> Tuple[List[int], List[int], int]:
+    ) -> tuple[list[int], list[int], int]:
     """
     For each dt window, choose the first timestamp in the window.
     Assumes timestamps sorted. One timestamp might be chosen multiple times due to dropped frames.
@@ -44,8 +44,8 @@ def get_accumulate_timestamp_idxs(
 
 
 def align_timestamps(    
-        timestamps: List[float], 
-        target_global_idxs: List[int], 
+        timestamps: list[float], 
+        target_global_idxs: list[int], 
         start_time: float, 
         dt: float, 
         eps:float=1e-5):
@@ -114,7 +114,7 @@ class TimestampObsAccumulator:
             return np.array([])
         return self.start_time + np.arange(len(self)) * self.dt
 
-    def put(self, data: Dict[str, np.ndarray], timestamps: np.ndarray):
+    def put(self, data: dict[str, np.ndarray], timestamps: np.ndarray):
         """
         data:
             key: T,*

--- a/qqtt/utils/config.py
+++ b/qqtt/utils/config.py
@@ -69,7 +69,7 @@ class Config:
                 setattr(self, key, value)
 
     def load_from_yaml(self, file_path):
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             config_dict = yaml.safe_load(file)
         self.update_from_dict(config_dict)
 

--- a/qqtt/utils/logger.py
+++ b/qqtt/utils/logger.py
@@ -90,7 +90,7 @@ class FileFormatter(Formatter):
 @singleton
 class ExpLogger(logging.Logger):
 
-    def __init__(self, name: Optional[str] = None):
+    def __init__(self, name: str | None = None):
         if name is None:
             name = time.strftime("%Y_%m%d_%H%M_%S", time.localtime(time.time()))
         super().__init__(name)
@@ -111,7 +111,7 @@ class ExpLogger(logging.Logger):
         self.removeHandler(self.stearmhandler)
 
     @master_only
-    def set_log_file(self, path: str, name: Optional[str] = None):
+    def set_log_file(self, path: str, name: str | None = None):
         if not os.path.exists(path):
             os.makedirs(path)
         file_path = os.path.join(


### PR DESCRIPTION
## Summary
- modernize qqtt helpers using Python 3.10 typing syntax
- document Python 3.10 typing convention in `playground_parameter_guide.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860a255842c832eacb005e7baf363e6