### PR TITLE
Add type hints to root Python scripts

### DIFF
--- a/evaluate_chamfer.py
+++ b/evaluate_chamfer.py
@@ -15,15 +15,15 @@ if not os.path.exists("results"):
     os.makedirs("results")
 
 def evaluate_prediction(
-    start_frame,
-    end_frame,
-    vertices,
-    object_points,
-    object_visibilities,
-    object_motions_valid,
-    num_original_points,
-    num_surface_points,
-):
+    start_frame: int,
+    end_frame: int,
+    vertices: torch.Tensor | np.ndarray,
+    object_points: torch.Tensor | np.ndarray,
+    object_visibilities: torch.Tensor | np.ndarray,
+    object_motions_valid: torch.Tensor | np.ndarray,
+    num_original_points: int,
+    num_surface_points: int,
+) -> dict[str, int | float]:
     chamfer_errors = []
 
     if not isinstance(vertices, torch.Tensor):

--- a/evaluate_track.py
+++ b/evaluate_track.py
@@ -10,7 +10,14 @@ prediction_path = "experiments"
 output_file = "results/final_track.csv"
 
 
-def evaluate_prediction(start_frame, end_frame, vertices, gt_track_3d, idx, mask):
+def evaluate_prediction(
+    start_frame: int,
+    end_frame: int,
+    vertices: np.ndarray,
+    gt_track_3d: np.ndarray,
+    idx: np.ndarray,
+    mask: np.ndarray,
+) -> float:
     track_errors = []
     for frame_idx in range(start_frame, end_frame):
         # Get the new mask and see

--- a/export_gaussian_data.py
+++ b/export_gaussian_data.py
@@ -10,7 +10,7 @@ output_path = "./data/gaussian_data"
 CONTROLLER_NAME = "hand"
 
 
-def existDir(dir_path):
+def existDir(dir_path: str) -> None:
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 

--- a/export_render_eval_data.py
+++ b/export_render_eval_data.py
@@ -7,7 +7,7 @@ output_path = "./data/render_eval_data"
 CONTROLLER_NAME = "hand"
 
 
-def existDir(dir_path):
+def existDir(dir_path: str) -> None:
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 

--- a/export_video_human_mask.py
+++ b/export_video_human_mask.py
@@ -4,7 +4,7 @@ import glob
 base_path = "./data/different_types"
 output_path = "./data/different_types_human_mask"
 
-def existDir(dir_path):
+def existDir(dir_path: str) -> None:
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 

--- a/gs_render_dynamics.py
+++ b/gs_render_dynamics.py
@@ -48,16 +48,16 @@ import pickle
 
 
 def render_set(
-    output_path,
-    name,
-    views,
-    gaussians_list,
-    pipeline,
-    background,
-    train_test_exp,
-    separate_sh,
-    disable_sh=False,
-):
+    output_path: str,
+    name: str,
+    views: list,
+    gaussians_list: list,
+    pipeline: PipelineParams,
+    background: torch.Tensor,
+    train_test_exp: bool,
+    separate_sh: bool,
+    disable_sh: bool = False,
+) -> None:
 
     render_path = os.path.join(output_path, name)
     makedirs(render_path, exist_ok=True)
@@ -114,7 +114,7 @@ def render_sets(
     remove_gaussians: bool = False,
     name: str = "dynamic",
     output_dir: str = "./gaussian_output_dynamic",
-):
+) -> None:
     with torch.no_grad():
         output_path = output_dir
 
@@ -222,7 +222,15 @@ def render_sets(
         )
 
 
-def rollout(xyz_0, rgb_0, quat_0, opa_0, ctrl_pts, n_steps, device="cuda"):
+def rollout(
+    xyz_0: torch.Tensor,
+    rgb_0: torch.Tensor,
+    quat_0: torch.Tensor,
+    opa_0: torch.Tensor,
+    ctrl_pts: torch.Tensor,
+    n_steps: int,
+    device: str = "cuda",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     # store results
     xyz = xyz_0.cpu()[None].repeat(n_steps, 1, 1)  # (n_steps, n_gaussians, 3)
     rgb = rgb_0.cpu()[None].repeat(n_steps, 1, 1)  # (n_steps, n_gaussians, 3)

--- a/gs_train.py
+++ b/gs_train.py
@@ -40,7 +40,16 @@ try:
 except:
     SPARSE_ADAM_AVAILABLE = False
 
-def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoint_iterations, checkpoint, debug_from):
+def training(
+    dataset: ModelParams,
+    opt: OptimizationParams,
+    pipe: PipelineParams,
+    testing_iterations: list[int],
+    saving_iterations: list[int],
+    checkpoint_iterations: list[int],
+    checkpoint: str | None,
+    debug_from: int,
+) -> None:
 
     if not SPARSE_ADAM_AVAILABLE and opt.optimizer_type == "sparse_adam":
         sys.exit(f"Trying to use sparse adam but it is not installed, please install the correct rasterizer using pip install [3dgs_accel].")
@@ -257,7 +266,7 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
                 print("\n[ITER {}] Saving Checkpoint".format(iteration))
                 torch.save((gaussians.capture(), iteration), scene.model_path + "/chkpnt" + str(iteration) + ".pth")
 
-def prepare_output_and_logger(args):    
+def prepare_output_and_logger(args: Namespace) -> SummaryWriter | None:
     if not args.model_path:
         if os.getenv('OAR_JOB_ID'):
             unique_str=os.getenv('OAR_JOB_ID')
@@ -279,7 +288,19 @@ def prepare_output_and_logger(args):
         print("Tensorboard not available: not logging progress")
     return tb_writer
 
-def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_iterations, scene : Scene, renderFunc, renderArgs, train_test_exp):
+def training_report(
+    tb_writer: SummaryWriter | None,
+    iteration: int,
+    Ll1: torch.Tensor,
+    loss: torch.Tensor,
+    l1_loss: torch.Tensor,
+    elapsed: float,
+    testing_iterations: list[int],
+    scene: Scene,
+    renderFunc,
+    renderArgs,
+    train_test_exp: bool,
+) -> None:
     if tb_writer:
         tb_writer.add_scalar('train_loss_patches/l1_loss', Ll1.item(), iteration)
         tb_writer.add_scalar('train_loss_patches/total_loss', loss.item(), iteration)

--- a/inference_warp.py
+++ b/inference_warp.py
@@ -11,7 +11,7 @@ import pickle
 import json
 
 
-def set_all_seeds(seed):
+def set_all_seeds(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)

--- a/interactive_playground.py
+++ b/interactive_playground.py
@@ -11,7 +11,7 @@ import pickle
 import json
 
 
-def set_all_seeds(seed):
+def set_all_seeds(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)

--- a/optimize_cma.py
+++ b/optimize_cma.py
@@ -11,7 +11,7 @@ import json
 from argparse import ArgumentParser
 
 
-def set_all_seeds(seed):
+def set_all_seeds(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)

--- a/process_data.py
+++ b/process_data.py
@@ -35,7 +35,7 @@ SHAPE_PRIOR = args.shape_prior
 logger = None
 
 
-def setup_logger(log_file="timer.log"):
+def setup_logger(log_file: str = "timer.log") -> None:
     global logger 
 
     if logger is None:
@@ -56,22 +56,27 @@ def setup_logger(log_file="timer.log"):
 setup_logger()
 
 
-def existDir(dir_path):
+def existDir(dir_path: str) -> None:
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 
 
 class Timer:
-    def __init__(self, task_name):
+    def __init__(self, task_name: str) -> None:
         self.task_name = task_name
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.start_time = time.time()
         logger.info(
             f"!!!!!!!!!!!! {self.task_name}: Processing {case_name} !!!!!!!!!!!!"
         )
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type | None,
+        exc_val: BaseException | None,
+        exc_tb,
+    ) -> None:
         elapsed_time = time.time() - self.start_time
         logger.info(
             f"!!!!!!!!!!! Time for {self.task_name}: {elapsed_time:.2f} sec !!!!!!!!!!!!"

--- a/train_warp.py
+++ b/train_warp.py
@@ -10,7 +10,7 @@ import pickle
 import json
 
 
-def set_all_seeds(seed):
+def set_all_seeds(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)

--- a/visualize_force.py
+++ b/visualize_force.py
@@ -9,7 +9,7 @@ import os
 import pickle
 import json
 
-def set_all_seeds(seed):
+def set_all_seeds(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)

--- a/visualize_material.py
+++ b/visualize_material.py
@@ -11,7 +11,7 @@ import pickle
 import json
 
 
-def set_all_seeds(seed):
+def set_all_seeds(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)


### PR DESCRIPTION
## Summary
- add type annotations for helper functions and classes
- type hint various rendering utilities
- type hint training utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bf229be8832eb7570534879d5f4b