### PR TITLE
Fix stiffness parameter loading

### DIFF
--- a/inference_warp.py
+++ b/inference_warp.py
@@ -34,23 +34,22 @@ if __name__ == "__main__":
     case_name = args.case_name
 
     if "cloth" in case_name or "package" in case_name:
-        cfg.load_from_yaml("configs/cloth.yaml")
+        yaml_path = "configs/cloth.yaml"
     else:
-        cfg.load_from_yaml("configs/real.yaml")
+        yaml_path = "configs/real.yaml"
 
-    logger.info(f"[DATA TYPE]: {cfg.data_type}")
-
-    base_dir = f"experiments/{case_name}"
-
-    # Read the first-satage optimized parameters to set the indifferentiable parameters
     optimal_path = f"experiments_optimization/{case_name}/optimal_params.pkl"
     logger.info(f"Load optimal parameters from: {optimal_path}")
     assert os.path.exists(
         optimal_path
     ), f"{case_name}: Optimal parameters not found: {optimal_path}"
-    with open(optimal_path, "rb") as f:
-        optimal_params = pickle.load(f)
-    cfg.set_optimal_params(optimal_params)
+
+    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
+
+    logger.info(f"[DATA TYPE]: {cfg.data_type}")
+
+    base_dir = f"experiments/{case_name}"
+
 
     # Set the intrinsic and extrinsic parameters for visualization
     with open(f"{base_path}/{case_name}/calibrate.pkl", "rb") as f:

--- a/interactive_playground.py
+++ b/interactive_playground.py
@@ -66,24 +66,19 @@ if __name__ == "__main__":
     case_name = args.case_name
 
     if "cloth" in case_name or "package" in case_name:
-        cfg.load_from_yaml("configs/cloth.yaml")
+        yaml_path = "configs/cloth.yaml"
     else:
-        cfg.load_from_yaml("configs/real.yaml")
+        yaml_path = "configs/real.yaml"
 
-    base_dir = f"./temp_experiments/{case_name}"
-
-    # Read the first-satage optimized parameters to set the indifferentiable parameters
     optimal_path = f"./experiments_optimization/{args.case_name}/optimal_params.pkl"
     logger.info(f"Loading optimal parameters from: {optimal_path}")
-
     if not os.path.exists(optimal_path):
         raise FileNotFoundError(
             f"{args.case_name}: Optimal parameters not found at {optimal_path}"
         )
 
-    with open(optimal_path, "rb") as f:
-        optimal_params = pickle.load(f)
-    cfg.set_optimal_params(optimal_params, use_global_spring_Y=args.use_optimal)
+    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path, use_global_spring_Y=args.use_optimal)
+    base_dir = f"./temp_experiments/{case_name}"
 
     # Set the intrinsic and extrinsic parameters for visualization
     with open(f"{base_path}/{case_name}/calibrate.pkl", "rb") as f:

--- a/optimize_cma.py
+++ b/optimize_cma.py
@@ -41,9 +41,9 @@ if __name__ == "__main__":
     max_iter = args.max_iter
 
     if "cloth" in case_name or "package" in case_name:
-        cfg.load_from_yaml("configs/cloth.yaml")
+        cfg.load_from_yaml_with_optimal("configs/cloth.yaml")
     else:
-        cfg.load_from_yaml("configs/real.yaml")
+        cfg.load_from_yaml_with_optimal("configs/real.yaml")
 
     base_dir = f"experiments_optimization/{case_name}"
 

--- a/tests/test_stiffness_loading.py
+++ b/tests/test_stiffness_loading.py
@@ -1,0 +1,51 @@
+import pickle
+import importlib.util
+import types
+import sys
+
+torch_stub = types.ModuleType("torch")
+torch_stub.distributed = types.ModuleType("distributed")
+sys.modules.setdefault("torch", torch_stub)
+
+pkg = types.ModuleType("qqtt")
+pkg.__path__ = ["qqtt"]
+sys.modules["qqtt"] = pkg
+utils_pkg = types.ModuleType("qqtt.utils")
+utils_pkg.__path__ = ["qqtt/utils"]
+sys.modules["qqtt.utils"] = utils_pkg
+
+spec_misc = importlib.util.spec_from_file_location(
+    "qqtt.utils.misc", "qqtt/utils/misc.py"
+)
+misc_mod = importlib.util.module_from_spec(spec_misc)
+sys.modules["qqtt.utils.misc"] = misc_mod
+spec_misc.loader.exec_module(misc_mod)
+
+spec = importlib.util.spec_from_file_location(
+    "qqtt.utils.config", "qqtt/utils/config.py"
+)
+config = importlib.util.module_from_spec(spec)
+sys.modules["qqtt.utils.config"] = config
+config.__package__ = "qqtt.utils"
+spec.loader.exec_module(config)
+cfg = config.cfg
+
+def test_stiffness_loading(tmp_path):
+    # zero-order stage: only load YAML
+    cfg.load_from_yaml_with_optimal('configs/real.yaml')
+    yaml_stiffness = cfg.init_spring_Y
+    assert isinstance(yaml_stiffness, float)
+
+    # create a pickle with different stiffness
+    new_val = yaml_stiffness + 10.0
+    pkl_path = tmp_path / 'opt.pkl'
+    with open(pkl_path, 'wb') as f:
+        pickle.dump({'global_spring_Y': new_val}, f)
+
+    # first-order stage: load YAML and override with pickle
+    cfg.load_from_yaml_with_optimal('configs/real.yaml', str(pkl_path))
+    assert cfg.init_spring_Y == new_val
+
+    # loading again should not change the value
+    cfg.load_from_yaml_with_optimal('configs/real.yaml', str(pkl_path))
+    assert cfg.init_spring_Y == new_val

--- a/train_warp.py
+++ b/train_warp.py
@@ -35,22 +35,17 @@ if __name__ == "__main__":
     train_frame = args.train_frame
 
     if "cloth" in case_name or "package" in case_name:
-        cfg.load_from_yaml("configs/cloth.yaml")
+        yaml_path = "configs/cloth.yaml"
     else:
-        cfg.load_from_yaml("configs/real.yaml")
+        yaml_path = "configs/real.yaml"
+
+    # Combine YAML loading and optimal parameter override in one step
+    optimal_path = f"experiments_optimization/{case_name}/optimal_params.pkl"
+    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
 
     print(f"[DATA TYPE]: {cfg.data_type}")
 
     base_dir = f"experiments/{case_name}"
-
-    # Read the first-satage optimized parameters
-    optimal_path = f"experiments_optimization/{case_name}/optimal_params.pkl"
-    assert os.path.exists(
-        optimal_path
-    ), f"{case_name}: Optimal parameters not found: {optimal_path}"
-    with open(optimal_path, "rb") as f:
-        optimal_params = pickle.load(f)
-    cfg.set_optimal_params(optimal_params)
 
     # Set the intrinsic and extrinsic parameters for visualization
     with open(f"{base_path}/{case_name}/calibrate.pkl", "rb") as f:

--- a/visualize_force.py
+++ b/visualize_force.py
@@ -23,7 +23,6 @@ seed = 42
 set_all_seeds(seed)
 
 if __name__ == "__main__":
-    cfg.load_from_yaml("configs/real.yaml")
 
     parser = ArgumentParser()
     parser.add_argument(
@@ -44,21 +43,18 @@ if __name__ == "__main__":
     case_name = args.case_name
 
     if "cloth" in case_name or "package" in case_name:
-        cfg.load_from_yaml("configs/cloth.yaml")
+        yaml_path = "configs/cloth.yaml"
     else:
-        cfg.load_from_yaml("configs/real.yaml")
+        yaml_path = "configs/real.yaml"
 
-    base_dir = f"./experiments/{case_name}"
-
-    # Read the first-satage optimized parameters to set the indifferentiable parameters
     optimal_path = f"./experiments_optimization/{case_name}/optimal_params.pkl"
     logger.info(f"Load optimal parameters from: {optimal_path}")
     assert os.path.exists(
         optimal_path
     ), f"{case_name}: Optimal parameters not found: {optimal_path}"
-    with open(optimal_path, "rb") as f:
-        optimal_params = pickle.load(f)
-    cfg.set_optimal_params(optimal_params)
+    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
+
+    base_dir = f"./experiments/{case_name}"
 
     # Set the intrinsic and extrinsic parameters for visualization
     with open(f"{base_path}/{case_name}/calibrate.pkl", "rb") as f:

--- a/visualize_material.py
+++ b/visualize_material.py
@@ -25,7 +25,6 @@ seed = 42
 set_all_seeds(seed)
 
 if __name__ == "__main__":
-    cfg.load_from_yaml("configs/real.yaml")
 
     parser = ArgumentParser()
     parser.add_argument(
@@ -45,21 +44,18 @@ if __name__ == "__main__":
     case_name = args.case_name
 
     if "cloth" in case_name or "package" in case_name:
-        cfg.load_from_yaml("configs/cloth.yaml")
+        yaml_path = "configs/cloth.yaml"
     else:
-        cfg.load_from_yaml("configs/real.yaml")
+        yaml_path = "configs/real.yaml"
 
-    base_dir = f"./experiments/{case_name}"
-
-    # Read the first-satage optimized parameters to set the indifferentiable parameters
     optimal_path = f"./experiments_optimization/{case_name}/optimal_params.pkl"
     logger.info(f"Load optimal parameters from: {optimal_path}")
     assert os.path.exists(
         optimal_path
     ), f"{case_name}: Optimal parameters not found: {optimal_path}"
-    with open(optimal_path, "rb") as f:
-        optimal_params = pickle.load(f)
-    cfg.set_optimal_params(optimal_params)
+    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
+
+    base_dir = f"./experiments/{case_name}"
 
     # Set the intrinsic and extrinsic parameters for visualization
     with open(f"{base_path}/{case_name}/calibrate.pkl", "rb") as f:


### PR DESCRIPTION
## Summary
- add `load_from_yaml_with_optimal` helper to prevent double-loading optimal params
- update optimization and inference scripts to use the helper
- add regression test for stiffness loading logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68670217f554832eb72ce8653d8a873c