### PR TITLE
Fix stiffness parameter loading logic

### DIFF
--- a/inference_warp.py
+++ b/inference_warp.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         optimal_path
     ), f"{case_name}: Optimal parameters not found: {optimal_path}"
 
-    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
+    cfg.load_first_order_params(yaml_path, optimal_path)
 
     logger.info(f"[DATA TYPE]: {cfg.data_type}")
 

--- a/interactive_playground.py
+++ b/interactive_playground.py
@@ -77,7 +77,9 @@ if __name__ == "__main__":
             f"{args.case_name}: Optimal parameters not found at {optimal_path}"
         )
 
-    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path, use_global_spring_Y=args.use_optimal)
+    cfg.load_first_order_params(
+        yaml_path, optimal_path, use_global_spring_Y=args.use_optimal
+    )
     base_dir = f"./temp_experiments/{case_name}"
 
     # Set the intrinsic and extrinsic parameters for visualization

--- a/optimize_cma.py
+++ b/optimize_cma.py
@@ -41,9 +41,9 @@ if __name__ == "__main__":
     max_iter = args.max_iter
 
     if "cloth" in case_name or "package" in case_name:
-        cfg.load_from_yaml_with_optimal("configs/cloth.yaml")
+        cfg.load_zero_order_params("configs/cloth.yaml")
     else:
-        cfg.load_from_yaml_with_optimal("configs/real.yaml")
+        cfg.load_zero_order_params("configs/real.yaml")
 
     base_dir = f"experiments_optimization/{case_name}"
 

--- a/tests/test_stiffness_loading.py
+++ b/tests/test_stiffness_loading.py
@@ -32,7 +32,7 @@ cfg = config.cfg
 
 def test_stiffness_loading(tmp_path):
     # zero-order stage: only load YAML
-    cfg.load_from_yaml_with_optimal('configs/real.yaml')
+    cfg.load_zero_order_params('configs/real.yaml')
     yaml_stiffness = cfg.init_spring_Y
     assert isinstance(yaml_stiffness, float)
 
@@ -43,9 +43,9 @@ def test_stiffness_loading(tmp_path):
         pickle.dump({'global_spring_Y': new_val}, f)
 
     # first-order stage: load YAML and override with pickle
-    cfg.load_from_yaml_with_optimal('configs/real.yaml', str(pkl_path))
+    cfg.load_first_order_params('configs/real.yaml', str(pkl_path))
     assert cfg.init_spring_Y == new_val
 
     # loading again should not change the value
-    cfg.load_from_yaml_with_optimal('configs/real.yaml', str(pkl_path))
+    cfg.load_first_order_params('configs/real.yaml', str(pkl_path))
     assert cfg.init_spring_Y == new_val

--- a/train_warp.py
+++ b/train_warp.py
@@ -39,9 +39,10 @@ if __name__ == "__main__":
     else:
         yaml_path = "configs/real.yaml"
 
-    # Combine YAML loading and optimal parameter override in one step
+    # First-order stage loads YAML and then the optimal parameters produced by
+    # the zero-order CMA-ES step.
     optimal_path = f"experiments_optimization/{case_name}/optimal_params.pkl"
-    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
+    cfg.load_first_order_params(yaml_path, optimal_path)
 
     print(f"[DATA TYPE]: {cfg.data_type}")
 

--- a/visualize_force.py
+++ b/visualize_force.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     assert os.path.exists(
         optimal_path
     ), f"{case_name}: Optimal parameters not found: {optimal_path}"
-    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
+    cfg.load_first_order_params(yaml_path, optimal_path)
 
     base_dir = f"./experiments/{case_name}"
 

--- a/visualize_material.py
+++ b/visualize_material.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     assert os.path.exists(
         optimal_path
     ), f"{case_name}: Optimal parameters not found: {optimal_path}"
-    cfg.load_from_yaml_with_optimal(yaml_path, optimal_path)
+    cfg.load_first_order_params(yaml_path, optimal_path)
 
     base_dir = f"./experiments/{case_name}"
 


### PR DESCRIPTION
## Summary
- avoid reloading optimal pickle when switching between zero and first-order optimization
- expose explicit `load_zero_order_params` and `load_first_order_params` helpers
- update training/inference scripts to use new API
- ensure repeated loads do not reset stiffness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686739ee94c8832e959d9632d69f0ee5