### PR TITLE
Enable optional YAML stiffness in playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,11 @@ conda activate phystwin_env
 python interactive_playground.py --inv_ctrl --n_ctrl_parts 2 --case_name double_lift_cloth_3
 ```
 
-Options: 
+Options:
 -   --inv_ctrl: inverse the control direction
--   --n_ctrol_parts: number of control panel (single: 1, double: 2) 
+-   --n_ctrol_parts: number of control panel (single: 1, double: 2)
 -   --case_name: case name of the PhysTwin case
+-   --ignore_checkpoint_stiffness: use stiffness from YAML instead of the trained model
 
 ### Train the PhysTwin with the data
 Use the processed data to train the PhysTwin. Instructions on how to get above `experiments_optimization`, `experiments` and `gaussian_output` (Can adjust the code below to only train on several cases). After this step, you get the PhysTwin that can be used in the interactive playground.

--- a/interactive_playground.py
+++ b/interactive_playground.py
@@ -59,6 +59,11 @@ if __name__ == "__main__":
         action="store_false",
         help="run from YAML only",
     )
+    parser.add_argument(
+        "--ignore_checkpoint_stiffness",
+        action="store_true",
+        help="do not load spring stiffness from the trained checkpoint",
+    )
     parser.set_defaults(use_optimal=True)
     args = parser.parse_args()
 
@@ -106,5 +111,9 @@ if __name__ == "__main__":
 
     best_model_path = glob.glob(f"experiments/{case_name}/train/best_*.pth")[0]
     trainer.interactive_playground(
-        best_model_path, gaussians_path, args.n_ctrl_parts, args.inv_ctrl
+        best_model_path,
+        gaussians_path,
+        args.n_ctrl_parts,
+        args.inv_ctrl,
+        ignore_checkpoint_stiffness=args.ignore_checkpoint_stiffness,
     )

--- a/playground_parameter_guide.md
+++ b/playground_parameter_guide.md
@@ -14,6 +14,7 @@ The Python code in this repository follows the standard type hinting syntax intr
 | `--case_name` | `double_lift_cloth_3` | Name of the case to load. All available cases can be found inside `data/different_types` or `data_config.csv`. |
 | `--n_ctrl_parts` | `2` | Number of control parts (hands). Use `1` for single‑hand or `2` for double‑hand control. |
 | `--inv_ctrl` | `False` | Invert the horizontal movement direction when pressing control keys. Useful when the camera faces the scene from the opposite direction. |
+| `--ignore_checkpoint_stiffness` | `False` | Keep `init_spring_Y` from the YAML instead of the trained checkpoint. |
 
 ## Detailed Explanations
 

--- a/qqtt/engine/trainer_warp.py
+++ b/qqtt/engine/trainer_warp.py
@@ -937,7 +937,13 @@ class InvPhyTrainerWarp:
         return self.structure_points[min_idx].unsqueeze(0)
 
     def interactive_playground(
-        self, model_path, gs_path, n_ctrl_parts=1, inv_ctrl=False
+        self,
+        model_path,
+        gs_path,
+        n_ctrl_parts=1,
+        inv_ctrl=False,
+        *,
+        ignore_checkpoint_stiffness=False,
     ):
         # Load the model
         logger.info(f"Load model from {model_path}")
@@ -954,7 +960,8 @@ class InvPhyTrainerWarp:
             len(spring_Y) == self.simulator.n_springs
         ), "Check if the loaded checkpoint match the config file to connect the springs"
 
-        self.simulator.set_spring_Y(torch.log(spring_Y).detach().clone())
+        if not ignore_checkpoint_stiffness:
+            self.simulator.set_spring_Y(torch.log(spring_Y).detach().clone())
         self.simulator.set_collide(
             collide_elas.detach().clone(), collide_fric.detach().clone()
         )


### PR DESCRIPTION
## Summary
- allow ignoring checkpoint spring stiffness so `init_spring_Y` can take effect
- expose the option via `--ignore_checkpoint_stiffness`
- document the new flag in README and playground guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686775f832a0832e9d4eb0a1477dbc8f