### PR TITLE
Print final spring stiffness

### DIFF
--- a/qqtt/engine/trainer_warp.py
+++ b/qqtt/engine/trainer_warp.py
@@ -962,6 +962,17 @@ class InvPhyTrainerWarp:
 
         if not ignore_checkpoint_stiffness:
             self.simulator.set_spring_Y(torch.log(spring_Y).detach().clone())
+
+        # Print the final spring stiffness used by the simulator for debugging
+        loaded_stiffness = (
+            wp.to_torch(self.simulator.wp_spring_Y, requires_grad=False)
+            .exp()
+            .cpu()
+            .numpy()
+        )
+        logger.info(
+            f"Final spring stiffness (first 10 values): {loaded_stiffness[:10]}"
+        )
         self.simulator.set_collide(
             collide_elas.detach().clone(), collide_fric.detach().clone()
         )

--- a/qqtt/utils/config.py
+++ b/qqtt/utils/config.py
@@ -1,4 +1,5 @@
 from .misc import singleton
+import logging
 import yaml
 import pickle
 
@@ -145,6 +146,9 @@ class Config:
 
         self.set_optimal_params(optimal_params, use_global_spring_Y=use_global_spring_Y)
         self._loaded_optimal_path = optimal_path
+
+        # Log the resulting spring stiffness for verification
+        logging.info(f"Config init_spring_Y loaded: {self.init_spring_Y}")
 
     def set_optimal_params(self, optimal_params, use_global_spring_Y=True):
         if use_global_spring_Y:


### PR DESCRIPTION
## Summary
- log the loaded spring stiffness in `load_first_order_params`
- report spring stiffness when launching the interactive playground

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cca4ba6f4832ea9898af0ab047d43